### PR TITLE
Add node_modules folder to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ vector_db
 context_store.db
 raggenie.db
 test_db.db
+
+# node_modules folder
+ui/node_modules


### PR DESCRIPTION
Include the node_modules folder in .gitignore file to avoid pushing node packages #19 