### PR TITLE
Remove mandatory requirement for column descriptions when adding database plugins

### DIFF
--- a/ui/src/pages/Configuration/ProviderForm/ProviderForm.jsx
+++ b/ui/src/pages/Configuration/ProviderForm/ProviderForm.jsx
@@ -495,10 +495,6 @@ const onRemoveFile = (fileId) => {
         Object.keys(localTableDetails).map(table_id=>{
             let tempCols = [];
             Object.keys(localTableDetails[table_id].columns).map(col_id=>{
-                if(localTableDetails[table_id].columns[col_id].description == ""){
-                    fullFill = false
-                }
-
                 tempCols.push({
                     column_id: col_id,
                     column_name: localTableDetails[table_id].columns[col_id].column_name,
@@ -522,12 +518,12 @@ const onRemoveFile = (fileId) => {
        
 
         if(fullFill == false){
-            toast.error("Please complete form")
+            toast.error("Table description is a required field. Please provide a valid description.")
             return
         }
 
         updateSchema(connectorId, tempTableDetails).then(response=>{
-            toast.success("Successfuly saved")
+            toast.success("Data saved successfully.")
             setCurrentActiveTab("documentation") 
         })
     }


### PR DESCRIPTION
Here’s an improved version of your PR description:

---

### Description
This PR resolves the issue where users were required to fill in all column descriptions when adding database plugins (e.g., PostgreSQL, Google BigQuery). Now, column descriptions are **optional**, while the table description remains **mandatory,** allowing the form to be saved without providing descriptions for every column.

### Changes
- Removed the mandatory validation for column descriptions.
- Made the table description a mandatory field in the database plugin form.

### Fixes Issue
#90

### Screenshots

![image](https://github.com/user-attachments/assets/1a532311-1f40-4afb-ab10-9f9cf3b863ee)

![image](https://github.com/user-attachments/assets/b0c3fec9-3807-478a-afd0-29e4fc843c89)

![image](https://github.com/user-attachments/assets/681dde89-9a07-469f-a34b-9c7b1020835d)


