### PR TITLE
Add delete functionality for samples

### DIFF
--- a/ui/src/pages/Samples/SampleList.jsx
+++ b/ui/src/pages/Samples/SampleList.jsx
@@ -2,54 +2,59 @@ import Button from "src/components/Button/Button"
 import { HiOutlinePlusCircle } from "react-icons/hi";
 import { FaPen } from "react-icons/fa6"
 import { BsQuestionSquare } from "react-icons/bs";
+import { FaTrash } from "react-icons/fa";
 import Table from "src/components/Table/Table"
 import style from "./Samples.module.css"
 import TitleDescription from "src/components/TitleDescription/TitleDescription";
 
 
-const SampleList = ({data, onCreate=()=>{}, onEdit = ()=>{}})=>{
+const SampleList = ({ data, onCreate = () => { }, onEdit = () => { }, onDelete = () => { } }) => {
 
 
-    const tableColums = [
-        {
-            name: 'Question List',
-            selector: row =><div className="flex flex-align-center flex-gap-10"> <span> <BsQuestionSquare color="#BEBEBE" size={18}/></span> <span> {row.description}</span> </div>  ,
-            grow: 1,
-        },
-        {
-            name: '',
-            selector: row => <><span onClick={()=>onEdit(row)}> <FaPen color="#84BCFF" size={16}/> </span></> ,
-            width: "80px"
-        },
-    ]
-
-    const rowExpandComponent = (row)=>{
-        return(
-             <div className={style.SampleExpandContaner}>
-                <div className={style.SampleExpandRow}>
-                    <span className={style.SampleRowLabel}>Query :</span> <span>{row.data?.sql_metadata?.query}</span>
-                </div>
-                <div className={style.SampleExpandRow}>
-                    <span className={style.SampleRowLabel} style={{marginRight: "5px"}}>Metadata :</span><span>{row.data?.sql_metadata?.metadata}</span>
-                </div>
-            </div>
-        )
-    }
-
-
-    return(
-        <div>
-            <div className="text-align-right" style={{marginBottom: "41px"}}>
-                <Button onClick={onCreate}>Create Sample <HiOutlinePlusCircle/></Button>
-            </div>
-            <div>
-                <TitleDescription title="Samples List" description="Please provide additional samples to enhance the accuracy and effectiveness of the results. More examples will help improve the quality of analysis and ensure better outcomes." />
-            </div>
-            <div>
-                <Table columns={tableColums} data={data} expandableRows={true} expandableRowsComponent={rowExpandComponent} />
-            </div>
+  const tableColums = [
+    {
+      name: 'Question List',
+      selector: row => <div className="flex flex-align-center flex-gap-10"> <span> <BsQuestionSquare color="#BEBEBE" size={18} /></span> <span> {row.description}</span> </div>,
+      grow: 1,
+    },
+    {
+      name: '',
+      selector: row => (
+        <div className="flex flex-align-center flex-gap-10">
+          <span onClick={() => onEdit(row)}> <FaPen color="#84BCFF" size={16} /> </span>
+          <span onClick={() => onDelete(row)}> <FaTrash color="#FF6B6B" size={16} /> </span>
         </div>
+      ),
+      width: "120px"
+    },
+  ]
+  const rowExpandComponent = (row) => {
+    return (
+      <div className={style.SampleExpandContaner}>
+        <div className={style.SampleExpandRow}>
+          <span className={style.SampleRowLabel}>Query :</span> <span>{row.data?.sql_metadata?.query}</span>
+        </div>
+        <div className={style.SampleExpandRow}>
+          <span className={style.SampleRowLabel} style={{ marginRight: "5px" }}>Metadata :</span><span>{row.data?.sql_metadata?.metadata}</span>
+        </div>
+      </div>
     )
+  }
+
+
+  return (
+    <div>
+      <div className="text-align-right" style={{ marginBottom: "41px" }}>
+        <Button onClick={onCreate}>Create Sample <HiOutlinePlusCircle /></Button>
+      </div>
+      <div>
+        <TitleDescription title="Samples List" description="Please provide additional samples to enhance the accuracy and effectiveness of the results. More examples will help improve the quality of analysis and ensure better outcomes." />
+      </div>
+      <div>
+        <Table columns={tableColums} data={data} expandableRows={true} expandableRowsComponent={rowExpandComponent} />
+      </div>
+    </div>
+  )
 
 }
 

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -1,7 +1,6 @@
 import DashboardBody from "src/layouts/dashboard/DashboadBody"
 import EmptySample from "./EmptySample"
 import Modal from "src/components/Modal/Modal"
-import { useEffect, useState } from "react"
 import SampleForm from "./SampleForm"
 import { getSamples, deleteSample } from "src/services/Sample"
 import SampleList from "./SampleList"
@@ -33,6 +32,13 @@ const Samples = () => {
     confirmDialog({
       title: "Delete Sample",
       message: "Are you sure you want to delete this sample?",
+      deleteButtonIconsvg: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M10.6667 4.00016V3.46683C10.6667 2.72009 10.6667 2.34672 10.5213 2.06151C10.3935 1.81063 10.1895 1.60665 9.93865 1.47882C9.65344 1.3335 9.28007 1.3335 8.53333 1.3335H7.46667C6.71993 1.3335 6.34656 1.3335 6.06135 1.47882C5.81046 1.60665 5.60649 1.81063 5.47866 2.06151C5.33333 2.34672 5.33333 2.72009 5.33333 3.46683V4.00016M6.66667 7.66683V11.0002M9.33333 7.66683V11.0002M2 4.00016H14M12.6667 4.00016V11.4668C12.6667 12.5869 12.6667 13.147 12.4487 13.5748C12.2569 13.9511 11.951 14.2571 11.5746 14.4488C11.1468 14.6668 10.5868 14.6668 9.46667 14.6668H6.53333C5.41323 14.6668 4.85318 14.6668 4.42535 14.4488C4.04903 14.2571 3.74307 13.9511 3.55132 13.5748C3.33333 13.147 3.33333 12.5869 3.33333 11.4668V4.00016" stroke="#FF7F6D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      ),
+      cancelButtonIconsvg: null,
+      confirmButtonText: "Delete",
       onConfirm: () => {
         deleteSample(sampleData.id).then(() => {
           getAllSamples()

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react"
 import SampleForm from "./SampleForm"
 import { getSamples, deleteSample } from "src/services/Sample"
 import SampleList from "./SampleList"
-import { confirmDailog } from "src/utils/confirmDialog"
+import { confirmDialog } from "src/utils/confirmDialog"
 import { toast } from "react-toastify"
 
 const Samples = () => {
@@ -46,7 +46,7 @@ const Samples = () => {
       })
     }
 
-    confirmDailog(
+    confirmDialog(
       "Are you sure you want to delete this sample?",
       "",
       deleteIcon,

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -1,10 +1,11 @@
 import DashboardBody from "src/layouts/dashboard/DashboadBody"
 import EmptySample from "./EmptySample"
 import Modal from "src/components/Modal/Modal"
+import { useEffect, useState } from "react"
 import SampleForm from "./SampleForm"
 import { getSamples, deleteSample } from "src/services/Sample"
 import SampleList from "./SampleList"
-import { confirmDialog } from "src/utils/confirmDialog"
+import { confirmDailog } from "src/utils/confirmDialog"
 import { toast } from "react-toastify"
 
 const Samples = () => {
@@ -29,26 +30,30 @@ const Samples = () => {
   }
 
   const onDelete = (sampleData) => {
-    confirmDialog({
-      title: "Delete Sample",
-      message: "Are you sure you want to delete this sample?",
-      deleteButtonIconsvg: (
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path d="M10.6667 4.00016V3.46683C10.6667 2.72009 10.6667 2.34672 10.5213 2.06151C10.3935 1.81063 10.1895 1.60665 9.93865 1.47882C9.65344 1.3335 9.28007 1.3335 8.53333 1.3335H7.46667C6.71993 1.3335 6.34656 1.3335 6.06135 1.47882C5.81046 1.60665 5.60649 1.81063 5.47866 2.06151C5.33333 2.34672 5.33333 2.72009 5.33333 3.46683V4.00016M6.66667 7.66683V11.0002M9.33333 7.66683V11.0002M2 4.00016H14M12.6667 4.00016V11.4668C12.6667 12.5869 12.6667 13.147 12.4487 13.5748C12.2569 13.9511 11.951 14.2571 11.5746 14.4488C11.1468 14.6668 10.5868 14.6668 9.46667 14.6668H6.53333C5.41323 14.6668 4.85318 14.6668 4.42535 14.4488C4.04903 14.2571 3.74307 13.9511 3.55132 13.5748C3.33333 13.147 3.33333 12.5869 3.33333 11.4668V4.00016" stroke="#FF7F6D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      ),
-      cancelButtonIconsvg: null,
-      confirmButtonText: "Delete",
-      onConfirm: () => {
-        deleteSample(sampleData.id).then(() => {
-          getAllSamples()
-          toast.success("Sample deleted successfully")
-        }).catch(error => {
-          console.error("Error deleting sample:", error)
-          toast.error("Failed to delete sample. Please try again.")
-        })
-      }
-    })
+    const deleteIcon = (
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+        <path d="M10.6667 4.00016V3.46683C10.6667 2.72009 10.6667 2.34672 10.5213 2.06151C10.3935 1.81063 10.1895 1.60665 9.93865 1.47882C9.65344 1.3335 9.28007 1.3335 8.53333 1.3335H7.46667C6.71993 1.3335 6.34656 1.3335 6.06135 1.47882C5.81046 1.60665 5.60649 1.81063 5.47866 2.06151C5.33333 2.34672 5.33333 2.72009 5.33333 3.46683V4.00016M6.66667 7.66683V11.0002M9.33333 7.66683V11.0002M2 4.00016H14M12.6667 4.00016V11.4668C12.6667 12.5869 12.6667 13.147 12.4487 13.5748C12.2569 13.9511 11.951 14.2571 11.5746 14.4488C11.1468 14.6668 10.5868 14.6668 9.46667 14.6668H6.53333C5.41323 14.6668 4.85318 14.6668 4.42535 14.4488C4.04903 14.2571 3.74307 13.9511 3.55132 13.5748C3.33333 13.147 3.33333 12.5869 3.33333 11.4668V4.00016" stroke="#FF7F6D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    )
+
+    const deleteFunction = () => {
+      deleteSample(sampleData.id).then(() => {
+        getAllSamples()
+        toast.success("Sample deleted successfully")
+      }).catch(error => {
+        console.error("Error deleting sample:", error)
+        toast.error("Failed to delete sample. Please try again.")
+      })
+    }
+
+    confirmDailog(
+      "Are you sure you want to delete this sample?",
+      "",
+      deleteIcon,
+      null,
+      "Delete",
+      deleteFunction
+    )
   }
 
   useEffect(() => {

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -6,6 +6,7 @@ import SampleForm from "./SampleForm"
 import { getSamples, deleteSample } from "src/services/Sample"
 import SampleList from "./SampleList"
 import { confirmDialog } from "src/utils/confirmDialog"
+import { toast } from "react-toastify"
 
 const Samples = () => {
   const [sampleList, setSampleList] = useState([])
@@ -35,10 +36,10 @@ const Samples = () => {
       onConfirm: () => {
         deleteSample(sampleData.id).then(() => {
           getAllSamples()
+          toast.success("Sample deleted successfully")
         }).catch(error => {
           console.error("Error deleting sample:", error)
-          // You can add a simple alert here if you want to show an error message
-          alert("Failed to delete sample. Please try again.")
+          toast.error("Failed to delete sample. Please try again.")
         })
       }
     })

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -3,48 +3,67 @@ import EmptySample from "./EmptySample"
 import Modal from "src/components/Modal/Modal"
 import { useEffect, useState } from "react"
 import SampleForm from "./SampleForm"
-import { getSamples } from "src/services/Sample"
+import { getSamples, deleteSample } from "src/services/Sample"
 import SampleList from "./SampleList"
+import { confirmDialog } from "src/utils/confirmDialog"
 
+const Samples = () => {
+  const [sampleList, setSampleList] = useState([])
+  const [showSampleModal, setSampleModal] = useState(false)
+  const [editSample, setEditSample] = useState({})
 
-const Samples = ()=>{
+  const getAllSamples = () => {
+    getSamples().then(response => {
+      setSampleList(response.data?.data?.sql ?? [])
+    })
+  }
 
-    const [sampleList, setSampleList] = useState([])
-    const [showSampleModal, setSampleModal] = useState(false)
-    const [editSample, setEditSample] = useState({})
+  const onEdit = (sampleData) => {
+    setSampleModal(true)
+    setEditSample(sampleData)
+  }
 
-    const  getAllSamples = ()=>{
-        getSamples().then(response=>{
-            setSampleList(response.data?.data?.sql ?? [])
+  const onCreateNew = () => {
+    setSampleModal(true)
+    setEditSample({})
+  }
+
+  const onDelete = (sampleData) => {
+    confirmDialog({
+      title: "Delete Sample",
+      message: "Are you sure you want to delete this sample?",
+      onConfirm: () => {
+        deleteSample(sampleData.id).then(() => {
+          getAllSamples()
+        }).catch(error => {
+          console.error("Error deleting sample:", error)
+          // You can add a simple alert here if you want to show an error message
+          alert("Failed to delete sample. Please try again.")
         })
-    }
+      }
+    })
+  }
 
-    const onEdit = (sampleData)=>{
-        setSampleModal(true)
-        setEditSample(sampleData)
-    }
+  useEffect(() => {
+    getAllSamples()
+  }, [])
 
-    const onCreateNew = ()=>{
-        setSampleModal(true)
-        setEditSample({})
-    }
-
-
-    useEffect(()=>{
-        getAllSamples()
-    }, [])
-
-    return(
-       <DashboardBody title="Samples">
-
-        { sampleList?.length == 0 && <EmptySample onCreateClick={()=>setSampleModal(true)} /> }
-        { sampleList?.length > 0 && <SampleList data={sampleList} onCreate={onCreateNew} onEdit={onEdit} /> }
-
-        <Modal title="Create Sample" show={showSampleModal} onClose={()=>setSampleModal(false)} >
-            <SampleForm sample={editSample} afterCreate={getAllSamples} onCancel={()=>setSampleModal(false)} />
-        </Modal>
-       </DashboardBody>
-    )
+  return (
+    <DashboardBody title="Samples">
+      {sampleList?.length == 0 && <EmptySample onCreateClick={() => setSampleModal(true)} />}
+      {sampleList?.length > 0 && (
+        <SampleList
+          data={sampleList}
+          onCreate={onCreateNew}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      )}
+      <Modal title="Create Sample" show={showSampleModal} onClose={() => setSampleModal(false)}>
+        <SampleForm sample={editSample} afterCreate={getAllSamples} onCancel={() => setSampleModal(false)} />
+      </Modal>
+    </DashboardBody>
+  )
 }
 
 export default Samples

--- a/ui/src/services/Sample.js
+++ b/ui/src/services/Sample.js
@@ -24,5 +24,5 @@ export const saveSamples = (sampleId, data) => {
 }
 
 export const deleteSample = (sampleId) => {
-  return DeleteService(API_URL + `/api/v1/sqldelete/${sampleId}`);
+  return DeleteService(`${API_URL}/sql/delete/${sampleId}`);
 }

--- a/ui/src/services/Sample.js
+++ b/ui/src/services/Sample.js
@@ -1,25 +1,28 @@
 import { API_URL } from "src/config/const";
 import GetService from "src/utils/http/GetService";
 import PostService from "src/utils/http/PostService";
+import DeleteService from "src/utils/http/DeleteService";
 
-export const getSamples = ()=>{
-    return GetService(API_URL + "/sql/list")
+export const getSamples = () => {
+  return GetService(API_URL + "/sql/list")
 }
 
-export const saveSamples = (sampleId, data)=>{
-    let apiURL = "/sql/create";
-    if(sampleId){
-        apiURL = `/sql/update/${sampleId}`;
+export const saveSamples = (sampleId, data) => {
+  let apiURL = "/sql/create";
+  if (sampleId) {
+    apiURL = `/sql/update/${sampleId}`;
+  }
+
+  return PostService(API_URL + apiURL, {
+    connector_id: data.connect_id,
+    description: data.question,
+    sql_metadata: {
+      query: data.query,
+      metadata: data.metadata
     }
-
-    return PostService(API_URL + apiURL, {
-        connector_id: data.connect_id,
-        description:  data.question,
-        sql_metadata: {
-            query: data.query,
-            metadata:  data.metadata
-        }
-    })
+  })
 }
 
-
+export const deleteSample = (sampleId) => {
+  return DeleteService(API_URL + `/api/v1/sqldelete/${sampleId}`);
+}

--- a/ui/src/services/Sample.js
+++ b/ui/src/services/Sample.js
@@ -24,5 +24,5 @@ export const saveSamples = (sampleId, data) => {
 }
 
 export const deleteSample = (sampleId) => {
-  return DeleteService(`${API_URL}/sql/delete/${sampleId}`);
+  return DeleteService(`${API_URL}/sqldelete/${sampleId}`);
 }

--- a/ui/src/utils/ConfirmDialog.jsx
+++ b/ui/src/utils/ConfirmDialog.jsx
@@ -2,168 +2,168 @@ import { confirmAlert } from "react-confirm-alert";
 import 'react-confirm-alert/src/react-confirm-alert.css';
 
 const defaultValue = {
-    icon: <svg xmlns="http://www.w3.org/2000/svg" width="31" height="30" viewBox="0 0 31 30" fill="none">
-        <path d="M15.5 20V15M15.5 10H15.5125M28 15C28 21.9036 22.4036 27.5 15.5 27.5C8.59644 27.5 3 21.9036 3 15C3 8.09644 8.59644 2.5 15.5 2.5C22.4036 2.5 28 8.09644 28 15Z" stroke="#FF7F6D" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>,
-    cancelButtonText: "Cancel",
-    confirmButtonText: "Delete",
-    deleteButtonIconsvg: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-        <path d="M10.6667 4.00016V3.46683C10.6667 2.72009 10.6667 2.34672 10.5213 2.06151C10.3935 1.81063 10.1895 1.60665 9.93865 1.47882C9.65344 1.3335 9.28007 1.3335 8.53333 1.3335H7.46667C6.71993 1.3335 6.34656 1.3335 6.06135 1.47882C5.81046 1.60665 5.60649 1.81063 5.47866 2.06151C5.33333 2.34672 5.33333 2.72009 5.33333 3.46683V4.00016M6.66667 7.66683V11.0002M9.33333 7.66683V11.0002M2 4.00016H14M12.6667 4.00016V11.4668C12.6667 12.5869 12.6667 13.147 12.4487 13.5748C12.2569 13.9511 11.951 14.2571 11.5746 14.4488C11.1468 14.6668 10.5868 14.6668 9.46667 14.6668H6.53333C5.41323 14.6668 4.85318 14.6668 4.42535 14.4488C4.04903 14.2571 3.74307 13.9511 3.55132 13.5748C3.33333 13.147 3.33333 12.5869 3.33333 11.4668V4.00016" stroke="#FF7F6D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>,
-    cancelButtonIconsvg: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-        <circle cx="8" cy="8" r="7.5" stroke="#3893FF" strokeWidth="1"/>
-        <path d="M5 5L11 11M11 5L5 11" stroke="#3893FF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>,
-    onCancel: () => { },
-    onConfirm: () => { }
+  icon: <svg xmlns="http://www.w3.org/2000/svg" width="31" height="30" viewBox="0 0 31 30" fill="none">
+    <path d="M15.5 20V15M15.5 10H15.5125M28 15C28 21.9036 22.4036 27.5 15.5 27.5C8.59644 27.5 3 21.9036 3 15C3 8.09644 8.59644 2.5 15.5 2.5C22.4036 2.5 28 8.09644 28 15Z" stroke="#FF7F6D" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  cancelButtonText: "Cancel",
+  confirmButtonText: "Delete",
+  deleteButtonIconsvg: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <path d="M10.6667 4.00016V3.46683C10.6667 2.72009 10.6667 2.34672 10.5213 2.06151C10.3935 1.81063 10.1895 1.60665 9.93865 1.47882C9.65344 1.3335 9.28007 1.3335 8.53333 1.3335H7.46667C6.71993 1.3335 6.34656 1.3335 6.06135 1.47882C5.81046 1.60665 5.60649 1.81063 5.47866 2.06151C5.33333 2.34672 5.33333 2.72009 5.33333 3.46683V4.00016M6.66667 7.66683V11.0002M9.33333 7.66683V11.0002M2 4.00016H14M12.6667 4.00016V11.4668C12.6667 12.5869 12.6667 13.147 12.4487 13.5748C12.2569 13.9511 11.951 14.2571 11.5746 14.4488C11.1468 14.6668 10.5868 14.6668 9.46667 14.6668H6.53333C5.41323 14.6668 4.85318 14.6668 4.42535 14.4488C4.04903 14.2571 3.74307 13.9511 3.55132 13.5748C3.33333 13.147 3.33333 12.5869 3.33333 11.4668V4.00016" stroke="#FF7F6D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  cancelButtonIconsvg: <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <circle cx="8" cy="8" r="7.5" stroke="#3893FF" strokeWidth="1" />
+    <path d="M5 5L11 11M11 5L5 11" stroke="#3893FF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>,
+  onCancel: () => { },
+  onConfirm: () => { }
 };
 
 const confirmDialogStyle = {
-    dialogBody: {
-        borderRadius: "8px",
-        boxShadow: "0px 4px 20px 0px rgba(0, 0, 0, 0.12)",
-        padding: "28px 40px",
-        width: "329px"
-    },
-    iconContainer: {
-        textAlign: "center"
-    },
-    icon: {
-        margin: "auto",
-        display: "block",
-        marginBottom: "23px",
-    },
-    dialogText: {
-        textAlign: "center"
-    },
-    dialogMainText: {
-        padding: "0px",
-        margin: "0px",
-        color: '#32324D',
-        textAlign: "center",
-        fontFamily: "Inter",
-        fontSize: "18px",
-        fontStyle: "normal",
-        fontWeight: "600",
-        lineHeight: "22px"
-    },
-    dialogSubText: {
-        color: "#32324D",
-        textAlign: "center",
-        fontFamily: "Inter",
-        fontSize: "14px",
-        fontStyle: "normal",
-        fontWeight: "400",
-        lineHeight: "20px",
-        marginBottom: "30px"
-    },
-    actionContainer: {
-        textAlign: "center"
-    },
-    cancelButton: {
-        padding: "3px 13px",
-        borderRadius: "4px",
-        background: "#ECF5FF",
-        border: "none",
-        focus: "none",
-        color: "#3893FF",
-        fontFamily: "Inter",
-        fontSize: "16px",
-        fontStyle: "normal",
-        fontWeight: "500",
-        lineHeight: "150%",
-        marginLeft: "10px"
-    },
-    deleteButton: {
-        padding: "3px 13px",
-        borderRadius: "4px",
-        background: "#FFF2F0",
-        border: "none",
-        focus: "none",
-        color: "#FF7F6D",
-        fontFamily: "Inter",
-        fontSize: "16px",
-        fontStyle: "normal",
-        fontWeight: "500",
-        lineHeight: "150%",
-        marginRight: "10px"
-    },
-    buttonContentAlign: {
-        display: "flex",
-        flexDirection: "row"
-    },
-    ButtonIcon: {
-        marginLeft: "5px"
-    }
+  dialogBody: {
+    borderRadius: "8px",
+    boxShadow: "0px 4px 20px 0px rgba(0, 0, 0, 0.12)",
+    padding: "28px 40px",
+    width: "329px"
+  },
+  iconContainer: {
+    textAlign: "center"
+  },
+  icon: {
+    margin: "auto",
+    display: "block",
+    marginBottom: "23px",
+  },
+  dialogText: {
+    textAlign: "center"
+  },
+  dialogMainText: {
+    padding: "0px",
+    margin: "0px",
+    color: '#32324D',
+    textAlign: "center",
+    fontFamily: "Inter",
+    fontSize: "18px",
+    fontStyle: "normal",
+    fontWeight: "600",
+    lineHeight: "22px"
+  },
+  dialogSubText: {
+    color: "#32324D",
+    textAlign: "center",
+    fontFamily: "Inter",
+    fontSize: "14px",
+    fontStyle: "normal",
+    fontWeight: "400",
+    lineHeight: "20px",
+    marginBottom: "30px"
+  },
+  actionContainer: {
+    textAlign: "center"
+  },
+  cancelButton: {
+    padding: "3px 13px",
+    borderRadius: "4px",
+    background: "#ECF5FF",
+    border: "none",
+    focus: "none",
+    color: "#3893FF",
+    fontFamily: "Inter",
+    fontSize: "16px",
+    fontStyle: "normal",
+    fontWeight: "500",
+    lineHeight: "150%",
+    marginLeft: "10px"
+  },
+  deleteButton: {
+    padding: "3px 13px",
+    borderRadius: "4px",
+    background: "#FFF2F0",
+    border: "none",
+    focus: "none",
+    color: "#FF7F6D",
+    fontFamily: "Inter",
+    fontSize: "16px",
+    fontStyle: "normal",
+    fontWeight: "500",
+    lineHeight: "150%",
+    marginRight: "10px"
+  },
+  buttonContentAlign: {
+    display: "flex",
+    flexDirection: "row"
+  },
+  ButtonIcon: {
+    marginLeft: "5px"
+  }
 };
 
 const confirmDialog = (
-    title,
-    message,
-    deleteButtonIconsvg = defaultValue.deleteButtonIconsvg,
-    cancelButtonIconsvg = defaultValue.cancelButtonIconsvg,
-    confirmButtonText = defaultValue.confirmButtonText,
-    onConfirm = defaultValue.onConfirm,
-    config = {}
+  title,
+  message,
+  deleteButtonIconsvg = defaultValue.deleteButtonIconsvg,
+  cancelButtonIconsvg = defaultValue.cancelButtonIconsvg,
+  confirmButtonText = defaultValue.confirmButtonText,
+  onConfirm = defaultValue.onConfirm,
+  config = {}
 ) => {
-    const allConfig = { ...defaultValue, ...config };
+  const allConfig = { ...defaultValue, ...config };
 
-    confirmAlert({
-        closeOnEscape: true,
-        customUI: ({ onClose }) => {
-            return (
-                <div>
-                    <div style={confirmDialogStyle.dialogBody}>
-                        <div style={confirmDialogStyle.iconContainer}>
-                            {allConfig.icon || defaultValue.icon}
-                        </div>
-                        <div style={confirmDialogStyle.dialogText}>
-                            <h6 style={confirmDialogStyle.dialogMainText}>{title}</h6>
-                            <p style={confirmDialogStyle.dialogSubText}>{message}</p>
-                        </div>
-                        <div style={confirmDialogStyle.actionContainer}>
-                            <button
-                                style={confirmDialogStyle.deleteButton}
-                                onClick={() => {
-                                    onConfirm();
-                                    onClose();
-                                }}
-                            >
-                                <div style={confirmDialogStyle.buttonContentAlign}>
-                                    <div>
-                                        {confirmButtonText}
-                                    </div>
-                                    {deleteButtonIconsvg && (
-                                        <div style={confirmDialogStyle.ButtonIcon}>
-                                            {deleteButtonIconsvg}
-                                        </div>
-                                    )}
-                                </div>
-                            </button>
-                            <button
-                                style={confirmDialogStyle.cancelButton}
-                                onClick={() => {
-                                    allConfig.onCancel();
-                                    onClose();
-                                }}
-                            >
-                                <div style={confirmDialogStyle.buttonContentAlign}>
-                                    <div>
-                                        {allConfig.cancelButtonText}
-                                    </div>
-                                    {cancelButtonIconsvg && (
-                                        <div style={confirmDialogStyle.ButtonIcon}>
-                                            {cancelButtonIconsvg}
-                                        </div>
-                                    )}
-                                </div>
-                            </button>
-                        </div>
+  confirmAlert({
+    closeOnEscape: true,
+    customUI: ({ onClose }) => {
+      return (
+        <div>
+          <div style={confirmDialogStyle.dialogBody}>
+            <div style={confirmDialogStyle.iconContainer}>
+              {allConfig.icon || defaultValue.icon}
+            </div>
+            <div style={confirmDialogStyle.dialogText}>
+              <h6 style={confirmDialogStyle.dialogMainText}>{title}</h6>
+              <p style={confirmDialogStyle.dialogSubText}>{message}</p>
+            </div>
+            <div style={confirmDialogStyle.actionContainer}>
+              <button
+                style={confirmDialogStyle.deleteButton}
+                onClick={() => {
+                  onConfirm();
+                  onClose();
+                }}
+              >
+                <div style={confirmDialogStyle.buttonContentAlign}>
+                  <div>
+                    {confirmButtonText}
+                  </div>
+                  {deleteButtonIconsvg && (
+                    <div style={confirmDialogStyle.ButtonIcon}>
+                      {deleteButtonIconsvg}
                     </div>
+                  )}
                 </div>
-            );
-        }
-    });
+              </button>
+              <button
+                style={confirmDialogStyle.cancelButton}
+                onClick={() => {
+                  allConfig.onCancel();
+                  onClose();
+                }}
+              >
+                <div style={confirmDialogStyle.buttonContentAlign}>
+                  <div>
+                    {allConfig.cancelButtonText}
+                  </div>
+                  {cancelButtonIconsvg && (
+                    <div style={confirmDialogStyle.ButtonIcon}>
+                      {cancelButtonIconsvg}
+                    </div>
+                  )}
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  });
 };
 
 export default confirmDialog;


### PR DESCRIPTION
Added delete functionality for issue #67. Used react-icons for trash icon for delete button. delete button is placed next to edit button.
Used the /api/v1/sqldelete/{id} API endpoint to perform the deletion.
Also added a confirmation prompt before deletion to prevent accidental removals using the confirmDialog function as well as some additional error handling.