### PR TITLE
Remove finish button on capabilities screen

### DIFF
--- a/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
+++ b/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
@@ -174,6 +174,7 @@ const BotConfiguration = () => {
         saveBotInferene(currentConfigID, currentInferenceID, data).then(() => {
             toast.success("Inference saved successfully")
             setShowNotificationPanel(false);
+            setActiveTab("capabalities")
         })
         .catch(() => {
             setShowNotificationPanel(true);
@@ -328,23 +329,23 @@ const BotConfiguration = () => {
                     <form onSubmit={configHandleSubmit(onBotConfigSave)}>
                         <div>
                         <Input 
-  label="Bot Configuration Name" 
-  maxLength={50} 
-  value={configWatch("botName")} 
-  hasError={configFormError["botName"]?.message ? true : false} 
-  errorMessage={configFormError["botName"]?.message}  
-  {...configRegister("botName", { 
-    required: "This field is required", 
-    maxLength: {
-      value: 50,
-      message: "The maximum length is 50 characters"
-    },
-    minLength: {
-      value: 10,
-      message: "The minimum length is 20 characters"
-    }
-  })} 
-/>
+                                label="Bot Configuration Name" 
+                                maxLength={50} 
+                                value={configWatch("botName")} 
+                                hasError={configFormError["botName"]?.message ? true : false} 
+                                errorMessage={configFormError["botName"]?.message}  
+                                {...configRegister("botName", { 
+                                    required: "This field is required", 
+                                    maxLength: {
+                                    value: 50,
+                                    message: "The maximum length is 50 characters"
+                                    },
+                                    minLength: {
+                                    value: 10,
+                                    message: "The minimum length is 20 characters"
+                                    }
+                                })} 
+                                />
                             <Input label="Bot Short Description" placeholder="brief detail about the use case of the bot" minLength={20} maxLength={200} value={configWatch("botShortDescription")} hasError={configFormError["botShortDescription"]?.message ? true : false} errorMessage={configFormError["botShortDescription"]?.message}  {...configRegister("botShortDescription", { required: "This field is required", minLength: {value: 20, message : "minimun length is 20"}, maxLength: {value: 200, message: "maximum length is 200"}})}  />
                             <Textarea label="Bot Long Description" placeholder="detailed information about the bot, including its full use case and functionalities" rows={10} minLength={50} maxLength={400} value={configWatch("botLongDescription")} hasError={configFormError["botLongDescription"]?.message ? true : false} errorMessage={configFormError["botLongDescription"]?.message}  {...configRegister("botLongDescription", { required: "This field is required", minLength:{value: 50, message: "minimun length is 50"}, maxLength: {value: 400, message: "maximum length is 400"}})} />
                             
@@ -380,7 +381,7 @@ const BotConfiguration = () => {
                         { showNotificationPanel && <NotificationPanel message={notificationMessage} containerStyle={{marginBottom: "30px"}} /> }
                         <div className={`${style.SaveConfigContainer} ${style.InferenceSaveContainer}`}>
                             <div style={{flexGrow: 1}}>
-                                <Button type="transparent" className="icon-button" onClick={()=>setActiveTab("configuration")} > <FaArrowLeft/> Back</Button>
+                                <Button type="transparent" className="icon-button" onClick={()=>{setActiveTab("configuration")}} > <FaArrowLeft/> Back</Button>
                             </div>
                             <div>
                                  { disabledInferenceSave && <Button onClick={onTestInference} style={{marginRight: "10px"}}> Test <LiaToolsSolid/>  </Button> }
@@ -419,7 +420,7 @@ const BotConfiguration = () => {
                             </div>
                             <div className={style.ActionDiv}>
                                 <div style={{flexGrow: 1}}>
-                                    <Button type="transparent" className="icon-button" onClick={()=>setCurrentActiveTab("documentation")}> <FaArrowLeft/> Back</Button>
+                                    <Button type="transparent" className="icon-button" onClick={()=>setActiveTab("inferenceendpoint")}> <FaArrowLeft/> Back</Button>
                                 </div>
                               
                             </div>

--- a/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
+++ b/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
@@ -98,8 +98,8 @@ const BotConfiguration = () => {
                 setSelectedOptions(tempSelectedCapabilities)
                 
 
-                 if(configs[0].capabalities?.length>0){
-                    setCapabalities(configs[0].capabalities)
+                 if(configs[0].capabilities?.length>0){
+                    setCapabalities(configs[0].capabilities)
                  } 
 
                 if(configs[0].inference[0]?.id){
@@ -397,6 +397,7 @@ const BotConfiguration = () => {
                                <Button variant="secondary" className="icon-button" onClick={addNewCapability}>New Capability <GoPlus/> </Button>
                             </div>
                             <div>
+                                
                                 {capabalities?.map((item, index)=>{
                                     return <Capability  
                                                 key={index}

--- a/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
+++ b/ui/src/pages/ChatConfiguration/ChatConfiguration.jsx
@@ -421,9 +421,7 @@ const BotConfiguration = () => {
                                 <div style={{flexGrow: 1}}>
                                     <Button type="transparent" className="icon-button" onClick={()=>setCurrentActiveTab("documentation")}> <FaArrowLeft/> Back</Button>
                                 </div>
-                                <div>
-                                    <Button buttonType="submit" className="icon-button" onClick={()=>navigate("/plugins")}>  Finish  <FiCheckCircle/></Button>
-                                </div>
+                              
                             </div>
                     </Tab>
             </Tabs>


### PR DESCRIPTION
### **Description**:

This PR removes the unnecessary **Finish** button from the Capabilities screen. Since data is already being saved to the backend using the **Save and Continue** buttons on previous tabs, and each capability has its own save button, the **Finish** button is redundant.

### **Proposed Changes**:
- Removed the **Finish** button from the Capabilities screen.
- Deleted any related code tied to the **Finish** button functionality.

### **Updates**:


![image](https://github.com/user-attachments/assets/cba46ed4-072a-4eef-819b-e162876fd397)

![image](https://github.com/user-attachments/assets/655371b4-a440-4d65-8274-3d036d99fea5)
