### PR TITLE
[FIX]: Prevents unnecessary text styles in input query on Copy-Paste 

### DIFF
--- a/ui/src/components/ChatBox/ChatBox.jsx
+++ b/ui/src/components/ChatBox/ChatBox.jsx
@@ -46,7 +46,7 @@ const ChatBox = forwardRef(({messageBoxRef = null, handleNavigateChatContext=()=
 
                     <div>
                         <div className={style.ChatBoxTextContainer}>
-                            <div ref={messageBoxRef} className={style.ChatBoxTextBox} contentEditable="true" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
+                            <div ref={messageBoxRef} className={style.ChatBoxTextBox} contentEditable="plaintext-only" onKeyDown={onKeyDown} onKeyUp={onKeyUp}>
                             </div>
                             <div>
                                 <div className={style.ChatBoxSendIcon} onClick={onSendClick}></div>


### PR DESCRIPTION
Prevents the style formatting of the text content from being copied into the query input.

Closes #120 