### PR TITLE
Fix CORS Error by Replacing DELETE with POST

### DIFF
--- a/app/api/v1/connector.py
+++ b/app/api/v1/connector.py
@@ -178,7 +178,7 @@ def update_connector(connector_id: int, connector: schemas.ConnectorUpdate, db: 
         error=None
     )
 
-@router.delete("/delete/{connector_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
+@router.post("/delete/{connector_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
 def delete_connector(connector_id: int, db: Session = Depends(get_db)):
 
     """
@@ -431,7 +431,7 @@ def update_capability(cap_id: int, capability: schemas.CapabilitiesUpdateBase, d
         data={"capability": result}
     )
 
-@cap_router.delete("/delete/{cap_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
+@cap_router.post("/delete/{cap_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
 def delete_capability(cap_id: int, db: Session = Depends(get_db)):
 
     """
@@ -813,7 +813,7 @@ def update_action(action_id: int, action: schemas.ActionsUpdate, db: Session = D
         error=None
     )
 
-@actions.delete("/{action_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
+@actions.post("/{action_id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
 def delete_action(action_id: int, db: Session = Depends(get_db)):
 
     """

--- a/app/api/v1/provider.py
+++ b/app/api/v1/provider.py
@@ -296,7 +296,7 @@ def update_sql(id: int, request: Request, sql: schemas.SampleSQLUpdate, db: Sess
         data={"sql": result}
     )
 
-@sample.delete("delete/{id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
+@sample.post("delete/{id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
 def delete_sql(id: int, db: Session = Depends(get_db)):
 
     """

--- a/ui/src/services/Capability.js
+++ b/ui/src/services/Capability.js
@@ -3,7 +3,7 @@ import DeleteService from "src/utils/http/DeleteService"
 import PostService from "src/utils/http/PostService"
 
 export const saveBotCapability = async (configurationId, capabilityName, capabilityDescription, params = {}) => {
-    
+
     let saveData = {
         config_id: configurationId,
         name: capabilityName,
@@ -26,5 +26,5 @@ export const updateBotCapability = async (capabilityId, configurationId, capabil
 }
 
 export const deleteBotCapability = async (capabilityId) => {
-    return DeleteService(`${API_URL}/capability/delete/${capabilityId}`,{},{loaderText: "Deleting Capability"})
+    return PostService(`${API_URL}/capability/delete/${capabilityId}`,{},{loaderText: "Deleting Capability"})
 }

--- a/ui/src/services/Connectors.js
+++ b/ui/src/services/Connectors.js
@@ -28,7 +28,7 @@ export const saveConnector = (connectorId = undefined, connectorType, connectorN
 }
 
 export const deleteConnector = (connectorId)=>{
-    return DeleteService(API_URL + `/connector/delete/${connectorId}`);
+    return PostService(API_URL + `/connector/delete/${connectorId}`);
 }
 
 export const updateDocument = (connectorId, document)=>{


### PR DESCRIPTION
This PR resolves a CORS error by replacing the DELETE method with a POST method for the affected API endpoint. This change helps avoid CORS-related issues.