### PR TITLE
Fix 500 Error in Airtable Credentials Test

### DIFF
--- a/app/plugins/airtable/handler.py
+++ b/app/plugins/airtable/handler.py
@@ -14,7 +14,7 @@ class Airtable(BasePlugin, QueryPlugin, PluginMetadataMixin, Formatter):
     Airtable class for interacting with Airtable API and fetching table data, schemas, and more.
     """
 
-    def __init__(self, token:str, workspace:str):
+    def __init__(self, api_key:str, space_name:str):
         super().__init__(__name__)
 
         self.connection = {
@@ -23,8 +23,8 @@ class Airtable(BasePlugin, QueryPlugin, PluginMetadataMixin, Formatter):
 
         # common
         self.params = {
-            'token': token,
-            'base_id': workspace
+            'token': api_key,
+            'base_id': space_name
         }
 
 


### PR DESCRIPTION
**Description:**
A 500 error occurs when testing Airtable credentials due to a mismatch in the credentials key. This PR resolves the issue by correcting the key mismatch.

