### PR TITLE
feat: Add delete functionality for samples

### DIFF
--- a/app/api/v1/provider.py
+++ b/app/api/v1/provider.py
@@ -356,7 +356,7 @@ def update_sql(id: int, request: Request, sql: schemas.SampleSQLUpdate, db: Sess
         data={"sql": result}
     )
 
-@sample.post("delete/{id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
+@sample.post("/delete/{id}", response_model=resp_schemas.CommonResponse, dependencies=[Depends(verify_token)])
 def delete_sql(id: int, db: Session = Depends(get_db)):
 
     """

--- a/ui/src/pages/Samples/SampleList.jsx
+++ b/ui/src/pages/Samples/SampleList.jsx
@@ -1,13 +1,13 @@
 import Button from "src/components/Button/Button"
 import { HiOutlinePlusCircle } from "react-icons/hi";
-import { FaPen } from "react-icons/fa6"
+import { FaPen, FaTrashCan } from "react-icons/fa6"
 import { BsQuestionSquare } from "react-icons/bs";
 import Table from "src/components/Table/Table"
 import style from "./Samples.module.css"
 import TitleDescription from "src/components/TitleDescription/TitleDescription";
 
 
-const SampleList = ({data, onCreate=()=>{}, onEdit = ()=>{}})=>{
+const SampleList = ({data, onCreate=()=>{}, onEdit = ()=>{},onDelete = ()=>{}})=>{
 
 
     const tableColums = [
@@ -19,8 +19,14 @@ const SampleList = ({data, onCreate=()=>{}, onEdit = ()=>{}})=>{
         {
             name: '',
             selector: row => <><span onClick={()=>onEdit(row)}> <FaPen color="#84BCFF" size={16}/> </span></> ,
+            width: "50px"
+        },
+        {
+            name: '',
+            selector: row => <><span onClick={()=>onDelete(row)}> <FaTrashCan color="#FF7F6D" size={16}/> </span></> ,
             width: "80px"
         },
+
     ]
 
     const rowExpandComponent = (row)=>{

--- a/ui/src/pages/Samples/Samples.jsx
+++ b/ui/src/pages/Samples/Samples.jsx
@@ -4,6 +4,7 @@ import Modal from "src/components/Modal/Modal"
 import { useEffect, useState } from "react"
 import SampleForm from "./SampleForm"
 import { getSamples } from "src/services/Sample"
+import { deleteSamples } from "src/services/Sample"
 import SampleList from "./SampleList"
 
 
@@ -23,6 +24,16 @@ const Samples = ()=>{
         setSampleModal(true)
         setEditSample(sampleData)
     }
+    
+    const onDelete = (sampleData)=>{
+        deleteSamples(sampleData.id)
+        setTimeout(() => {
+            getAllSamples()
+        },10)
+
+    }
+
+     
 
     const onCreateNew = ()=>{
         setSampleModal(true)
@@ -38,7 +49,7 @@ const Samples = ()=>{
        <DashboardBody title="Samples">
 
         { sampleList?.length == 0 && <EmptySample onCreateClick={()=>setSampleModal(true)} /> }
-        { sampleList?.length > 0 && <SampleList data={sampleList} onCreate={onCreateNew} onEdit={onEdit} /> }
+        { sampleList?.length > 0 && <SampleList data={sampleList} onCreate={onCreateNew} onEdit={onEdit} onDelete={onDelete}/> }
 
         <Modal title="Create Sample" show={showSampleModal} onClose={()=>setSampleModal(false)} >
             <SampleForm sample={editSample} afterCreate={getAllSamples} onCancel={()=>setSampleModal(false)} />

--- a/ui/src/services/Sample.js
+++ b/ui/src/services/Sample.js
@@ -6,6 +6,11 @@ export const getSamples = ()=>{
     return GetService(API_URL + "/sql/list")
 }
 
+export const deleteSamples = (sampleId)=>{
+    return PostService(API_URL + `/sql/delete/${sampleId}`)
+
+}
+
 export const saveSamples = (sampleId, data)=>{
     let apiURL = "/sql/create";
     if(sampleId){


### PR DESCRIPTION
 - Updated the API endpoint in `provider.py` to include a leading slash in the delete route.
 - Enhanced `SampleList.jsx` to include a delete button with `FaTrashCan` icon.
 - Modified `Samples.jsx` to handle delete operations by integrating `deleteSamples` service.
 - Added `deleteSamples` function in `Sample.js` to call the delete API endpoint.
 - Adjusted UI components to refresh the sample list after deletion.
 
 
![image](https://github.com/user-attachments/assets/d5f10671-f039-47b9-a0bb-456bd8de59df)
